### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ logs
 coverage
 config.json
 .vscode
+.idea
+.python-version


### PR DESCRIPTION
`.gitignore` を加筆しました。

一点は、JetBrainsのIDEの関連ファイルです。
もう一点は、 `pyenv` のローカルバージョンを指定するファイルです。
`pyenv` を使っていてグローバルなバージョンが3系だと `yarn` や `npm i` するときに下記エラーが出てしまうので、ローカルバージョンを指定出来るようにしたく、追加しました。

```
> weak@1.0.1 install /Users/yudai524/Desktop/Arbitrager/r2/node_modules/weak
> node-gyp rebuild

gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp ERR! configure error
gyp ERR! stack Error: Command failed: /Users/yudai524/.pyenv/shims/python2 -c import platform; print(platform.python_version());
gyp ERR! stack pyenv: python2: command not found
gyp ERR! stack
gyp ERR! stack The `python2' command exists in these Python versions:
gyp ERR! stack   2.7.11
gyp ERR! stack   2.7.13
gyp ERR! stack
gyp ERR! stack
gyp ERR! stack     at ChildProcess.exithandler (child_process.js:275:12)
gyp ERR! stack     at emitTwo (events.js:126:13)
gyp ERR! stack     at ChildProcess.emit (events.js:214:7)
gyp ERR! stack     at maybeClose (internal/child_process.js:925:16)
gyp ERR! stack     at Socket.stream.socket.on (internal/child_process.js:346:11)
gyp ERR! stack     at emitOne (events.js:116:13)
gyp ERR! stack     at Socket.emit (events.js:211:7)
gyp ERR! stack     at Pipe._handle.close [as _onclose] (net.js:554:12)
gyp ERR! System Darwin 16.7.0
gyp ERR! command "/Users/yudai524/.nvm/versions/node/v8.9.0/bin/node" "/Users/yudai524/.nvm/versions/node/v8.9.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /Users/yudai524/Desktop/Arbitrager/r2/node_modules/weak
gyp ERR! node -v v8.9.0
gyp ERR! node-gyp -v v3.6.2
gyp ERR! not ok
npm WARN r2@2.1.0 No repository field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: weak@1.0.1 (node_modules/weak):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: weak@1.0.1 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1
```