### PR TITLE
Issue/41 fix generate nonce

### DIFF
--- a/src/__tests__/util.test.ts
+++ b/src/__tests__/util.test.ts
@@ -10,18 +10,8 @@ test('mkdir', () => {
   expect(() => util.mkdir(1)).toThrow();
 });
 
-test('nonce', async () => {
-  const result = [];
-  setTimeout(() => result.push(util.nonce()), 50);
-  setTimeout(() => result.push(util.nonce()), 50);
-  setTimeout(() => result.push(util.nonce()), 50);
-  setTimeout(() => result.push(util.nonce()), 50);
-  setTimeout(() => result.push(util.nonce()), 50);
-  setTimeout(() => result.push(util.nonce()), 50);
-  await util.delay(100);
-  const resultSet = new Set(result);
-  expect(result.length).toBe(6);
-  expect(result.length).toBe(resultSet.size);
+test('nonce', () => {
+  expect(util.nonce().length).toBe(19);
 });
 
 test('almostEqual', () => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -40,18 +40,9 @@ export function hmac(secret: string, text: string, algo: string = 'sha256'): str
     .digest('hex');
 }
 
-export const nonce: () => string = (function() {
-  let prev = 0;
-  return function() {
-    const n = Date.now();
-    if (n <= prev) {
-      prev += 1;
-      return prev.toString();
-    }
-    prev = n;
-    return prev.toString();
-  };
-})();
+export function nonce(): string  {
+  return (Date.now() * 1000000).toString();
+}
 
 export function timestampToDate(n: number): Date {
   return new Date(n * 1000);


### PR DESCRIPTION
close #41 

nonceの生成桁数を19桁にしました。
これより少なくとも(1000倍程度でも)通ることは確認しているため、
1000000倍にしていることに特に強い理由はないです。