### PR TITLE
ポジションクローズ時のオープンペア情報の削除について #43

### DIFF
--- a/src/LimitCheckerFactoryImpl.ts
+++ b/src/LimitCheckerFactoryImpl.ts
@@ -10,7 +10,7 @@ export default class LimitCheckerFactoryImpl implements LimitCheckerFactory {
     @inject(symbols.PositionService) private readonly positionService: PositionService
   ) {}
 
-  create(spreadAnalysisResult: SpreadAnalysisResult, exitFlag: boolean): LimitChecker {
-    return new LimitCheckerImpl(this.configStore, this.positionService, spreadAnalysisResult, exitFlag);
+  create(spreadAnalysisResult: SpreadAnalysisResult, closableOrdersKey: string): LimitChecker {
+    return new LimitCheckerImpl(this.configStore, this.positionService, spreadAnalysisResult, closableOrdersKey);
   }
 } /* istanbul ignore next */

--- a/src/LimitCheckerImpl.ts
+++ b/src/LimitCheckerImpl.ts
@@ -11,9 +11,9 @@ export default class LimitCheckerImpl implements LimitChecker {
     configStore: ConfigStore,
     positionService: PositionService,
     spreadAnalysisResult: SpreadAnalysisResult,
-    exitFlag: boolean
+    closableOrdersKey: string
   ) {
-    if (exitFlag) {
+    if (closableOrdersKey) {
       this.limits = [
         new MaxNetExposureLimit(configStore, positionService),
         new MaxTargetProfitLimit(configStore, spreadAnalysisResult),

--- a/src/SingleLegHandler.ts
+++ b/src/SingleLegHandler.ts
@@ -22,11 +22,11 @@ export default class SingleLegHandler {
     private readonly onSingleLegConfig: OnSingleLegConfig
   ) {}
 
-  async handle(orders: OrderPair, exitFlag: Boolean): Promise<OrderImpl[]> {
+  async handle(orders: OrderPair, closableOrdersKey: string): Promise<OrderImpl[]> {
     if (this.onSingleLegConfig === undefined) {
       return [];
     }
-    const action = exitFlag ? this.onSingleLegConfig.actionOnExit : this.onSingleLegConfig.action;
+    const action = closableOrdersKey ? this.onSingleLegConfig.actionOnExit : this.onSingleLegConfig.action;
     if (action === undefined || action === 'Cancel') {
       return [];
     }


### PR DESCRIPTION
下記の対応を行いました。
お役に立てば幸いです。

LimitCheck の結果が NG の場合はオープンペア情報を削除しない。
