### PR TITLE
Quoine規約変更時のAPIエラーメッセージ追加

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,5 +5,6 @@ export const fatalErrors = [
   'Too Many Requests',
   'Service Unavailable',
   '所持金額が足りません',
-  'not_enough_free_balance'
+  'not_enough_free_balance',
+  'Conditions and Trading Rules before continuing'
 ];


### PR DESCRIPTION
Quoineにて利用規約が変更となった場合に、注文を出すと
ERROR [Arbitrager] HTTP request failed. Response from https://api.quoine.com/orders/. Status Code: 422 (Unprocessable Entity) Content: {"message":"Please go to our Trading site (https://trade.quoinex.com) to review Terms, Conditions and Trading Rules before continuing."}
の返答が帰ってきて、注文が処理されない状況となります。
この事象は、Quoineのサイトで新利用規約に同意するまで続きます。

その為、constants.tsに上記のメッセージを追加し、即座にアプリケーションが停止するようにしました。
また、このAPIの動作が曲者で注文以外の応答は行うので、利用規約が変更になっても板情報の取得は出来てしまうため、裁定機会を発見し注文するまで気づかないのです。

もし、よろしければマージをお願いします。