### PR TITLE
minTargetProfitPercentを動的に読み込む試み

### DIFF
--- a/src/MainLimitChecker.ts
+++ b/src/MainLimitChecker.ts
@@ -10,6 +10,7 @@ import * as _ from 'lodash';
 import t from './intl';
 import PositionService from './PositionService';
 import { calcProfit } from './pnl';
+import * as fs from 'fs';
 
 export default class MainLimitChecker implements LimitChecker {
   private readonly log = getLogger(this.constructor.name);
@@ -136,7 +137,10 @@ class MinTargetProfitLimit implements LimitChecker {
   }
 
   private isTargetProfitLargeEnough(): boolean {
-    const config = this.configStore.config;
+    const { config } = this.configStore;
+    if (fs.existsSync('./src/opt/minTargetProfitPercent.txt')) {
+      config.minTargetProfitPercent = Number(fs.readFileSync('./src/opt/minTargetProfitPercent.txt', 'utf-8'));
+    }
     const { bestBid, bestAsk, targetVolume, targetProfit } = this.spreadAnalysisResult;
     const targetVolumeNotional = _.mean([bestAsk.price, bestBid.price]) * targetVolume;
     const effectiveMinTargetProfit = _.max([


### PR DESCRIPTION
現状の動作ですと、起動時にconfigStoreに設定を格納した後は、再起動するまで不変となっています。

クオート情報等をcsvに吐き出す機能を追加して頂けるとなると、そこから最適値を計算して、動的に変えれたらと思い、「./src/opt/minTargetProfitPercent.txt」が存在していた場合は、その数値を利用する設定を追加してみました。
2案であったプラグイン追加までのつなぎのような設定になります。
プラグインが追加されたら邪魔だと思いますので削除して頂ければ、、、

minTargetProfitPercent.txtの更新は各々ShellScript等を自作して、cronで定期実行すればいいかなと思ってます。
minTargetProfitPercent.txtの中身は設定値だけ書いて頂くのを想定してます。

拙いアイディアですがもしよければお使い下さい。

PS.
const { config } = this.configStore;
の部分は他と合わせてみました。