### PR TITLE
QuoineCB発動時のエラーメッセージを追加

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,5 +6,6 @@ export const fatalErrors = [
   'Service Unavailable',
   '所持金額が足りません',
   'not_enough_free_balance',
-  'Conditions and Trading Rules before continuing'
+  'Conditions and Trading Rules before continuing',
+  'product_disabled'
 ];


### PR DESCRIPTION
Quoineにてサーキットブレイクが発動した時に注文した場合に返されるエラーメッセージを追加しました。

ちなみにサーキットブレイク時のログは下記になります。
2018-01-17 07:33:39.577 ERROR [Arbitrager] HTTP request failed. Response from https://api.quoine.com/orders/. Status Code: 422 (Unprocessable Entity) Content: {"errors":{"order":["product_disabled"]}}