### PR TITLE
売り買い試行許可の判定に　maxTargetVolumePercent　を考慮するように変更

### DIFF
--- a/src/SpreadAnalyzer.ts
+++ b/src/SpreadAnalyzer.ts
@@ -41,7 +41,11 @@ export default class SpreadAnalyzer {
     }
     let filteredQuotes = _(quotes)
       .filter(q => this.isAllowedByCurrentPosition(q, positionMap[q.broker]))
-      .filter(q => new Decimal(q.volume).gte(config.minSize))
+      .filter(q => new Decimal(q.volume).gte(
+        (closingPair ? closingPair[0].size : config.minSize) *
+          _.floor(config.maxTargetVolumePercent !== undefined
+            ? 100 / config.maxTargetVolumePercent
+            : 1)))
       .orderBy(['price'])
       .value();
     if (closingPair) {

--- a/src/__tests__/SpreadAnalyzerImpl.test.ts
+++ b/src/__tests__/SpreadAnalyzerImpl.test.ts
@@ -221,4 +221,27 @@ describe('Spread Analyzer', () => {
     const spreadStat = await target.getSpreadStat(quotes);
     expect(spreadStat).not.toBeUndefined();
   });
+
+  test('analyze with maxTargetVolumePercent definition', async () => {
+    config.minSize = 0.5;
+    config.maxTargetVolumePercent = 25.0;
+    config.brokers[2].commissionPercent = 0.0;
+    const quotes = [
+      toQuote('Coincheck', QuoteSide.Ask, 300000, 1),
+      toQuote('Coincheck', QuoteSide.Bid, 200000, 2),
+      toQuote('Quoine', QuoteSide.Ask, 350000, 3),
+      toQuote('Quoine', QuoteSide.Bid, 360000, 4)
+    ];
+    const target = new SpreadAnalyzer(configStore);
+    const result = await target.analyze(quotes, positionMap);
+    expect(result.ask.broker).toBe('Quoine');
+    expect(result.ask.price).toBe(350000);
+    expect(result.ask.volume).toBe(3);
+    expect(result.bid.broker).toBe('Quoine');
+    expect(result.bid.price).toBe(360000);
+    expect(result.bid.volume).toBe(4);
+    expect(result.invertedSpread).toBe(10000);
+    expect(result.targetVolume).toBe(0.5);
+    expect(result.targetProfit).toBe(5000);
+  });
 });


### PR DESCRIPTION
売り買い試行許可の判定に　maxTargetVolumePercent　を考慮するように変更しました。
条件に満たないビッドとアスクは事前に排除され、別の取引所で機会を探すことができます。
関連：https://qiita.com/bitrinjani/items/92453dc6b1d8fa52a19a#comment-f56cb3face5cb53a171f
※MaxTargetVolumeLimit のチェックが不要になるわけではなく、minSize と maxSize が異なる場合に有効です。