### PR TITLE
指値注文時に設定値分不利な注文を行う機能を追加

### DIFF
--- a/src/PairTrader.ts
+++ b/src/PairTrader.ts
@@ -104,10 +104,10 @@ export default class PairTrader extends EventEmitter {
     const { cashMarginType, leverageLevel } = brokerConfig;
     const orderSide = quote.side === QuoteSide.Ask ? OrderSide.Buy : OrderSide.Sell;
     const orderPrice = 
-     (quote.side == QuoteSide.Ask && config.AcceptablePriceRange != undefined)
-     ? _.round(quote.price * (1 + config.AcceptablePriceRange/100)) as number
-     : (quote.side == QuoteSide.Bid && config.AcceptablePriceRange != undefined)
-     ? _.round(quote.price * (1 - config.AcceptablePriceRange/100)) as number
+     (quote.side === QuoteSide.Ask && config.acceptablePriceRange !== undefined)
+     ? _.round(quote.price * (1 + config.acceptablePriceRange/100)) as number
+     : (quote.side === QuoteSide.Bid && config.acceptablePriceRange !== undefined)
+     ? _.round(quote.price * (1 - config.acceptablePriceRange/100)) as number
      : quote.price;
     const order = new OrderImpl({
       symbol: this.configStore.config.symbol,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -101,6 +101,7 @@ export class ConfigRoot extends Castable {
   @cast maxTargetProfit: number;
   @cast maxTargetProfitPercent: number;
   @cast maxTargetVolumePercent: number;
+  @cast AcceptablePriceRange: number;
   @cast iterationInterval: number;
   @cast positionRefreshInterval: number;
   @cast sleepAfterSend: number;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -101,7 +101,7 @@ export class ConfigRoot extends Castable {
   @cast maxTargetProfit: number;
   @cast maxTargetProfitPercent: number;
   @cast maxTargetVolumePercent: number;
-  @cast AcceptablePriceRange: number;
+  @cast acceptablePriceRange: number;
   @cast iterationInterval: number;
   @cast positionRefreshInterval: number;
   @cast sleepAfterSend: number;

--- a/webui/src/app/types/config.ts
+++ b/webui/src/app/types/config.ts
@@ -101,6 +101,7 @@ export class ConfigRoot extends Castable {
   @cast maxTargetProfit: number;
   @cast maxTargetProfitPercent: number;
   @cast maxTargetVolumePercent: number;
+  @cast AcceptablePriceRange: number;
   @cast iterationInterval: number;
   @cast positionRefreshInterval: number;
   @cast sleepAfterSend: number;

--- a/webui/src/app/types/config.ts
+++ b/webui/src/app/types/config.ts
@@ -101,7 +101,7 @@ export class ConfigRoot extends Castable {
   @cast maxTargetProfit: number;
   @cast maxTargetProfitPercent: number;
   @cast maxTargetVolumePercent: number;
-  @cast AcceptablePriceRange: number;
+  @cast acceptablePriceRange: number;
   @cast iterationInterval: number;
   @cast positionRefreshInterval: number;
   @cast sleepAfterSend: number;


### PR DESCRIPTION
成行注文のような動作を作れないかと思い、`acceptablePriceRange`の%分だけ、不利な注文を実施する機能を追加してみました。
`acceptablePriceRange`は0.5とか0.1といった低い数値を設定する事を想定しています。
もしよろしければマージをお願いします。
Testデータの作り方がいまいちわからず、申し訳ないです。