### PR TITLE
api.liquid.com

### DIFF
--- a/src/Bitflyer/BrokerApi.ts
+++ b/src/Bitflyer/BrokerApi.ts
@@ -17,7 +17,7 @@ import {
 } from './types';
 
 export default class BrokerApi {
-  private readonly baseUrl = 'https://api.bitflyer.jp';
+  private readonly baseUrl = 'https://api.bitflyer.com';
   private readonly webClient: WebClient = new WebClient(this.baseUrl);
 
   constructor(private readonly key: string, private readonly secret: string) {}

--- a/src/Quoine/BrokerApi.ts
+++ b/src/Quoine/BrokerApi.ts
@@ -16,7 +16,7 @@ import {
 import * as jwt from 'jsonwebtoken';
 
 export default class BrokerApi {
-  private readonly baseUrl = 'https://api.quoine.com';
+  private readonly baseUrl = 'https://api.liquid.com';
   private readonly webClient: WebClient = new WebClient(this.baseUrl);
 
   constructor(private readonly key: string, private readonly secret: string) {}

--- a/src/__tests__/Bitflyer/nocksetup.ts
+++ b/src/__tests__/Bitflyer/nocksetup.ts
@@ -2,7 +2,7 @@
 import * as nock from 'nock';
 
 function nocksetup() {
-  const api = nock('https://api.bitflyer.jp');
+  const api = nock('https://api.bitflyer.com');
   api
     .get('/v1/me/getbalance')
     .reply(200, [

--- a/src/__tests__/Quoine/nocksetup.ts
+++ b/src/__tests__/Quoine/nocksetup.ts
@@ -3,7 +3,7 @@
 import * as nock from 'nock';
 
 function nocksetup() {
-  const quoine = nock('https://api.quoine.com');
+  const quoine = nock('https://api.liquid.com');
   quoine.get('/orders/118573146').reply(200, {
     id: 118573146,
     order_type: 'limit',


### PR DESCRIPTION
Liquid by Quoine エンドポイント変更のお知らせメールが届いたので対応しました。
(旧) https://api.quoine.com/
(新) https://api.liquid.com/
bitflyerのエンドポイントも変更しました。
(旧) https://api.bitflyer.jp/
(新) https://api.bitflyer.com/